### PR TITLE
Fixed dns module for 'state=absent' and removed redundant 'False'

### DIFF
--- a/library/cisco_ucs_dns.py
+++ b/library/cisco_ucs_dns.py
@@ -96,13 +96,14 @@ def setup_dns(server, module):
 
     if ansible["state"] == "present":
         if module.check_mode or exists:
-            return not exists, False
+            return not exists
         dns_server_add(handle=server, **args_mo)
     else:
         if module.check_mode or not exists:
-            return exists, False
-        dns_server_remove(server, trap_id)
-    return True, False
+            return exists
+        dns_server_remove(server, mo.name)
+
+    return True
 
 
 def setup(server, module):
@@ -110,7 +111,7 @@ def setup(server, module):
     err = False
 
     try:
-        result["changed"], err = setup_dns(server, module)
+        result["changed"] = setup_dns(server, module)
     except Exception as e:
         err = True
         result["msg"] = "setup error: %s " % str(e)


### PR DESCRIPTION
- Fixed dns module for 'state=absent'
- Removed redundant 'False' in return statement.

Signed-off-by: Rahul Gupta <ragupta4@cisco.com>