### PR TITLE
Issue #46

### DIFF
--- a/library/ucs_vnic_template.py
+++ b/library/ucs_vnic_template.py
@@ -161,7 +161,7 @@ EXAMPLES = r'''
     vlans_list:
     - name: default
       native: 'yes'
-    - name: finance
+      state: present
 
 - name: Remove vNIC template
   ucs_vnic_template:
@@ -178,6 +178,18 @@ EXAMPLES = r'''
     password: password
     name: vNIC-A-B
     state: absent
+    
+- name: Remove VLAN from template
+  ucs_vnic_template:
+    hostname: 172.16.143.150
+    username: admin
+    password: password
+    name: vNIC-A-B
+    fabric: A-B
+    vlans_list:
+    - name: default
+      native: 'yes'
+      state: absent
 '''
 
 RETURN = r'''


### PR DESCRIPTION
Updated to allow for addition and removal of VLAN after vNIC template creation.

VLANS will need state attribute declared.

EXAMPLE:

vnic_primary_templates:
  - name: mgmt0
    fabric: A-B
    redundancy_type: primary
    template_type: updating-template
    mtu: '9000'
    mac_pool: fabricA
    network_control_policy: enable-cdp-lldp
    state: present
    vlans_list:
      - name: ESXI_MGMT
        native: "yes"
        state: present
      - name: vlan5
        native: "no"
        state: present
      - name: vlan4
        native: "no"
        state: absent


## TODO update examples and docstrings