### PR TITLE
Closes #114 to allow Outband mgmt IP none when using Inband Management

### DIFF
--- a/library/ucs_service_profile_template.py
+++ b/library/ucs_service_profile_template.py
@@ -103,9 +103,14 @@ options:
   sol_policy:
     description:
     - The name of the Serial over LAN (SoL) policy you want to associate with service profiles created from this template.
+  mgmt_ip_state:
+    description:
+    - The state for the Outband Management IP pool you want to use with service profiles created from this template.
+    choices: [none, pooled]
+    default: pooled
   mgmt_ip_pool:
     description:
-    - The name of the management IP pool you want to use with service profiles created from this template.
+    - The name of the Outband Management IP pool you want to use with service profiles created from this template.
     default: ext-mgmt
   power_control_policy:
     description:
@@ -207,7 +212,7 @@ def configure_service_profile_template(ucs, module):
                 bios_profile_name=module.params['bios_policy'],
                 boot_policy_name=module.params['boot_policy'],
                 descr=module.params['description'],
-                ext_ip_state='pooled',
+                ext_ip_state=module.params['mgmt_ip_state'],
                 ext_ip_pool_name=module.params['mgmt_ip_pool'],
                 # graphics_card_policy_name=module.params['graphics_card_policy'],
                 host_fw_policy_name=module.params['host_firmware_package'],
@@ -404,6 +409,7 @@ def check_serivce_profile_templates_props(ucs, module, mo, dn):
     kwargs = dict(bios_profile_name=module.params['bios_policy'])
     kwargs['boot_policy_name'] = module.params['boot_policy']
     kwargs['descr'] = module.params['description']
+    kwargs['ext_ip_state'] = module.params['mgmt_ip_state']
     kwargs['ext_ip_pool_name'] = module.params['mgmt_ip_pool']
     # kwargs['graphics_card_policy_name'] = module.params['graphics_card_policy']
     kwargs['host_fw_policy_name'] = module.params['host_firmware_package']
@@ -454,6 +460,7 @@ def main():
         bios_policy=dict(type='str', default=''),
         boot_policy=dict(type='str', default='default'),
         description=dict(type='str', aliases=['descr'], default=''),
+        mgmt_ip_state=dict(type='str', default='pooled'),
         mgmt_ip_pool=dict(type='str', default='ext-mgmt'),
         graphics_card_policy=dict(type='str', default=''),
         host_firmware_package=dict(type='str', default=''),


### PR DESCRIPTION
example :
mgmt_ip_state: none
mgmt_interface_mode: in-band
mgmt_vnet_name: inband-mgmt
mgmt_inband_pool_name: inband-mgmt