### PR TITLE
Fix description option  in ucs_wwn_pool.py

### DIFF
--- a/library/ucs_wwn_pool.py
+++ b/library/ucs_wwn_pool.py
@@ -124,7 +124,7 @@ def main():
         org_dn=dict(type='str', default='org-root'),
         name=dict(type='str'),
         purpose=dict(type='str', choices=['node', 'port']),
-        descr=dict(type='str'),
+        descr=dict(type='str', default='', aliases=['description', 'descrption']),
         order=dict(type='str', default='default', choices=['default', 'sequential']),
         first_addr=dict(type='str'),
         last_addr=dict(type='str'),


### PR DESCRIPTION
Documentation for module says that it has option "description" but it does not work. It needs "descr". Just make it on par with ucs_mac_pool module which uses aliases for "descr" and default value.